### PR TITLE
Move attachments and archive...

### DIFF
--- a/addons/crm_project_issue/project_issue.py
+++ b/addons/crm_project_issue/project_issue.py
@@ -21,6 +21,7 @@ class crm_lead_to_project_issue_wizard(osv.TransientModel):
         wizards = self.browse(cr, uid, ids, context=context)
         Lead = self.pool["crm.lead"]
         Issue = self.pool["project.issue"]
+        Attachment = self.pool['ir.attachment']
 
         for wizard in wizards:
             # get the lead to transform
@@ -43,8 +44,20 @@ class crm_lead_to_project_issue_wizard(osv.TransientModel):
             issue_id = Issue.create(cr, uid, vals, context=None)
             # move the mail thread
             Lead.message_change_thread(cr, uid, lead.id, issue_id, "project.issue", context=context)
-            # delete the lead
-            Lead.unlink(cr, uid, [lead.id], context=None)
+            # Move attachments
+            attachment_ids = Attachment.search(
+                cr, uid,
+                [('res_model', '=', 'crm.lead'), ('res_id', '=', lead.id)],
+                context=context
+            )
+            Attachment.write(
+                cr, uid, attachment_ids,
+                {'res_model': 'project.issue', 'res_id': issue_id},
+                context=context
+            )
+            # Archive the lead
+            Lead.write(cr, uid, [lead.id], {'active': False}, context=context)
+
         # return the action to go to the form view of the new Issue
         view_id = self.pool.get('ir.ui.view').search(cr, uid, [('model', '=', 'project.issue'), ('name', '=', 'project_issue_form_view')])
         return {


### PR DESCRIPTION
...the lead instead of deleting it as implemented in the version 9

**Description of the issue/feature this PR addresses:**
Move the attachments to the project issue which resulted from a converted lead with crm_project_issue module

**Current behavior before PR:**
When converting crm.leads to project.issues, the attachments are not moved, and since the lead is deleted afterwards, the attachments get actually lost

**Desired behavior after PR is merged:**
The attachments get moved to the newly created issue and the source lead gets archived (deactivated) instead of being deleted.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr